### PR TITLE
Support all hmac hash algorithms that are available in crypto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## master
+
+* Enhancements
+  * Allow all HMAC hash algorithms [supported in the crypto lib](https://erlang.org/doc/man/crypto.html#type-hmac_hash_algorithm).
+
 ## v1.4.0 - 2021-04-08
 
 * Changes

--- a/lib/pbkdf2.ex
+++ b/lib/pbkdf2.ex
@@ -153,10 +153,19 @@ defmodule Pbkdf2 do
   """
   @impl true
   def verify_pass(password, stored_hash) do
-    [alg, rounds, salt, hash] = String.split(stored_hash, "$", trim: true)
-    digest = if alg =~ "sha512", do: :sha512, else: :sha256
+    [prefix, rounds, salt, hash] = String.split(stored_hash, "$", trim: true)
+    digest = hash_prefix_to_digest(prefix)
+
     Base.verify_pass(password, hash, salt, digest, rounds, output(stored_hash))
   end
+
+  defp hash_prefix_to_digest("pbkdf2" <> _ = prefix) do
+    prefix
+    |> String.slice(7..-1)
+    |> String.to_existing_atom()
+  end
+
+  defp hash_prefix_to_digest(digest), do: String.to_existing_atom(digest)
 
   defp output("$pbkdf2" <> _), do: :modular
   defp output("pbkdf2" <> _), do: :django

--- a/lib/pbkdf2/base.ex
+++ b/lib/pbkdf2/base.ex
@@ -73,7 +73,16 @@ defmodule Pbkdf2.Base do
       Keyword.get(opts, :rounds, Application.get_env(:pbkdf2_elixir, :rounds, 160_000)),
       Keyword.get(opts, :format, :modular),
       case opts[:digest] do
+        :md4 -> {:md4, opts[:length] || 32}
+        :md5 -> {:md5, opts[:length] || 32}
+        :sha -> {:sha, opts[:length] || 32}
+        :sha224 -> {:sha224, opts[:length] || 32}
         :sha256 -> {:sha256, opts[:length] || 32}
+        :sha384 -> {:sha384, opts[:length] || 32}
+        :sha3_224 -> {:sha3_224, opts[:length] || 32}
+        :sha3_256 -> {:sha3_256, opts[:length] || 32}
+        :sha3_384 -> {:sha3_384, opts[:length] || 32}
+        :sha3_512 -> {:sha3_512, opts[:length] || 64}
         _ -> {:sha512, opts[:length] || 64}
       end
     }

--- a/test/base_test.exs
+++ b/test/base_test.exs
@@ -15,6 +15,150 @@ defmodule Pbkdf2.BaseTest do
     end
   end
 
+  test "base pbkdf2_md4 tests" do
+    [
+      {
+        "passDATAb00AB7YxDTT",
+        "saltKEYbcTcXHCBxtjD",
+        100_000,
+        "$pbkdf2-md4$100000$c2FsdEtFWWJjVGNYSENCeHRqRA$BCScq1KoBh1SxktpMbcMDC8xWfj2T3WW7DdJD7i7M2I"
+      },
+      {
+        "passDATAb00AB7YxDTTl",
+        "saltKEYbcTcXHCBxtjD2",
+        100_000,
+        "$pbkdf2-md4$100000$c2FsdEtFWWJjVGNYSENCeHRqRDI$i6.6ohjhMQoZu3pOwvsajT2Owt/9jxPTTUucaTRLt0I"
+      },
+      {
+        "passDATAb00AB7YxDTTlRH2dqxDx19GDxDV1zFMz7E6QVqKIzwOtMnlxQLttpE5",
+        "saltKEYbcTcXHCBxtjD2PnBh44AIQ6XUOCESOhXpEp3HrcGMwbjzQKMSaf63IJe",
+        100_000,
+        "$pbkdf2-md4$100000$c2FsdEtFWWJjVGNYSENCeHRqRDJQbkJoNDRBSVE2WFVPQ0VTT2hYcEVwM0hyY0dNd2JqelFLTVNhZjYzSUpl$t5E8zh7jYJW6H/T9dCizLZcqDnndH4i1ELijCaycSUY"
+      }
+    ]
+    |> check_vectors(:md4)
+  end
+
+  test "base pbkdf2_md5 tests" do
+    [
+      {
+        "passDATAb00AB7YxDTT",
+        "saltKEYbcTcXHCBxtjD",
+        100_000,
+        "$pbkdf2-md5$100000$c2FsdEtFWWJjVGNYSENCeHRqRA$K2rAet/4BO3vXhAixgKM7d54NSKq5PyLq3KiyT5BppY"
+      },
+      {
+        "passDATAb00AB7YxDTTl",
+        "saltKEYbcTcXHCBxtjD2",
+        100_000,
+        "$pbkdf2-md5$100000$c2FsdEtFWWJjVGNYSENCeHRqRDI$gGCF9oSJfaIvpkDJb66NduaLiMxGGnKl.DQngVXTRC0"
+      },
+      {
+        "passDATAb00AB7YxDTTlRH2dqxDx19GDxDV1zFMz7E6QVqKIzwOtMnlxQLttpE5",
+        "saltKEYbcTcXHCBxtjD2PnBh44AIQ6XUOCESOhXpEp3HrcGMwbjzQKMSaf63IJe",
+        100_000,
+        "$pbkdf2-md5$100000$c2FsdEtFWWJjVGNYSENCeHRqRDJQbkJoNDRBSVE2WFVPQ0VTT2hYcEVwM0hyY0dNd2JqelFLTVNhZjYzSUpl$rgvaGebYhpPWwBhXSJaaqXUJLsSZG30YiBwmWPnFPSY"
+      }
+    ]
+    |> check_vectors(:md5)
+  end
+
+  test "base pbkdf2_sha tests" do
+    [
+      {
+        "passDATAb00AB7YxDTT",
+        "saltKEYbcTcXHCBxtjD",
+        100_000,
+        "$pbkdf2-sha$100000$c2FsdEtFWWJjVGNYSENCeHRqRA$tJOhy631DHZdCOVNGIA0MttkywU8gSl5XoAvulUVlqA"
+      },
+      {
+        "passDATAb00AB7YxDTTl",
+        "saltKEYbcTcXHCBxtjD2",
+        100_000,
+        "$pbkdf2-sha$100000$c2FsdEtFWWJjVGNYSENCeHRqRDI$foDXm179EG9KC5aG3N1rYsKcnq0ve0NFIx8LhOaGvD8"
+      },
+      {
+        "passDATAb00AB7YxDTTlRH2dqxDx19GDxDV1zFMz7E6QVqKIzwOtMnlxQLttpE5",
+        "saltKEYbcTcXHCBxtjD2PnBh44AIQ6XUOCESOhXpEp3HrcGMwbjzQKMSaf63IJe",
+        100_000,
+        "$pbkdf2-sha$100000$c2FsdEtFWWJjVGNYSENCeHRqRDJQbkJoNDRBSVE2WFVPQ0VTT2hYcEVwM0hyY0dNd2JqelFLTVNhZjYzSUpl$yBI5QPTwnktUHUmd7l7x7NLglZxZqVeZ00Tphh2/7W8"
+      }
+    ]
+    |> check_vectors(:sha)
+  end
+
+  test "base pbkdf2_sha224 tests" do
+    [
+      {
+        "passDATAb00AB7YxDTT",
+        "saltKEYbcTcXHCBxtjD",
+        100_000,
+        "$pbkdf2-sha224$100000$c2FsdEtFWWJjVGNYSENCeHRqRA$gIzBTgAdt2f1t01eNMRX6Z88RIiD4Xwccvf.13gwJ7E"
+      },
+      {
+        "passDATAb00AB7YxDTTl",
+        "saltKEYbcTcXHCBxtjD2",
+        100_000,
+        "$pbkdf2-sha224$100000$c2FsdEtFWWJjVGNYSENCeHRqRDI$ca3b8uw2r5k2nD6gCXiDtJgfI4YS9eIqHN4rOmeYJbM"
+      },
+      {
+        "passDATAb00AB7YxDTTlRH2dqxDx19GDxDV1zFMz7E6QVqKIzwOtMnlxQLttpE5",
+        "saltKEYbcTcXHCBxtjD2PnBh44AIQ6XUOCESOhXpEp3HrcGMwbjzQKMSaf63IJe",
+        100_000,
+        "$pbkdf2-sha224$100000$c2FsdEtFWWJjVGNYSENCeHRqRDJQbkJoNDRBSVE2WFVPQ0VTT2hYcEVwM0hyY0dNd2JqelFLTVNhZjYzSUpl$PUexjY9O2JA504B/8/bU2eFcFYqKRYj8i5dqDVJ5VBk"
+      }
+    ]
+    |> check_vectors(:sha224)
+  end
+
+  test "base pbkdf2_sha256 tests" do
+    [
+      {
+        "passDATAb00AB7YxDTT",
+        "saltKEYbcTcXHCBxtjD",
+        100_000,
+        "$pbkdf2-sha256$100000$c2FsdEtFWWJjVGNYSENCeHRqRA$rIq6SFKrPmE2K/.VNRiY5K0mPzqnwYtTOB7BPitbZ5U"
+      },
+      {
+        "passDATAb00AB7YxDTTl",
+        "saltKEYbcTcXHCBxtjD2",
+        100_000,
+        "$pbkdf2-sha256$100000$c2FsdEtFWWJjVGNYSENCeHRqRDI$FKa6HSFOmTo5B.5U0up17LY6o8aL2o/bDKM..y./OT0"
+      },
+      {
+        "passDATAb00AB7YxDTTlRH2dqxDx19GDxDV1zFMz7E6QVqKIzwOtMnlxQLttpE5",
+        "saltKEYbcTcXHCBxtjD2PnBh44AIQ6XUOCESOhXpEp3HrcGMwbjzQKMSaf63IJe",
+        100_000,
+        "$pbkdf2-sha256$100000$c2FsdEtFWWJjVGNYSENCeHRqRDJQbkJoNDRBSVE2WFVPQ0VTT2hYcEVwM0hyY0dNd2JqelFLTVNhZjYzSUpl$3hZq8FgVonszF2YucuzBObJikR.HkMzmK10Q2c9L49w"
+      }
+    ]
+    |> check_vectors(:sha256)
+  end
+
+  test "base pbkdf2_sha384 tests" do
+    [
+      {
+        "passDATAb00AB7YxDTT",
+        "saltKEYbcTcXHCBxtjD",
+        100_000,
+        "$pbkdf2-sha384$100000$c2FsdEtFWWJjVGNYSENCeHRqRA$05AhNZYUxfNCmBD6J6Fdp1HO9Z1931bMmOhAbmkdhHk"
+      },
+      {
+        "passDATAb00AB7YxDTTl",
+        "saltKEYbcTcXHCBxtjD2",
+        100_000,
+        "$pbkdf2-sha384$100000$c2FsdEtFWWJjVGNYSENCeHRqRDI$HuZ1yYbHaZ7.QCRrJw2fMOgWe.ZZSZHhXRdOWXCCKmg"
+      },
+      {
+        "passDATAb00AB7YxDTTlRH2dqxDx19GDxDV1zFMz7E6QVqKIzwOtMnlxQLttpE5",
+        "saltKEYbcTcXHCBxtjD2PnBh44AIQ6XUOCESOhXpEp3HrcGMwbjzQKMSaf63IJe",
+        100_000,
+        "$pbkdf2-sha384$100000$c2FsdEtFWWJjVGNYSENCeHRqRDJQbkJoNDRBSVE2WFVPQ0VTT2hYcEVwM0hyY0dNd2JqelFLTVNhZjYzSUpl$BjurYEAL7vTNkAkiq0iw5GL9O0cNZnGyCYDxLOzDFgQ"
+      }
+    ]
+    |> check_vectors(:sha384)
+  end
+
   test "base pbkdf2_sha512 tests" do
     [
       {
@@ -37,6 +181,102 @@ defmodule Pbkdf2.BaseTest do
       }
     ]
     |> check_vectors
+  end
+
+  test "base pbkdf2_sha3_224 tests" do
+    [
+      {
+        "passDATAb00AB7YxDTT",
+        "saltKEYbcTcXHCBxtjD",
+        100_000,
+        "$pbkdf2-sha3_224$100000$c2FsdEtFWWJjVGNYSENCeHRqRA$ME2MHQNmBvIgX.Ch.nqdyi/InlXM2lmpnrHSUNjowzA"
+      },
+      {
+        "passDATAb00AB7YxDTTl",
+        "saltKEYbcTcXHCBxtjD2",
+        100_000,
+        "$pbkdf2-sha3_224$100000$c2FsdEtFWWJjVGNYSENCeHRqRDI$8WtHbsGqW6nOrPmXwGA80Kfn3d7uTkB/HnvbcRm7rWk"
+      },
+      {
+        "passDATAb00AB7YxDTTlRH2dqxDx19GDxDV1zFMz7E6QVqKIzwOtMnlxQLttpE5",
+        "saltKEYbcTcXHCBxtjD2PnBh44AIQ6XUOCESOhXpEp3HrcGMwbjzQKMSaf63IJe",
+        100_000,
+        "$pbkdf2-sha3_224$100000$c2FsdEtFWWJjVGNYSENCeHRqRDJQbkJoNDRBSVE2WFVPQ0VTT2hYcEVwM0hyY0dNd2JqelFLTVNhZjYzSUpl$ZspKPqKU0BWicwi9LVDYpmbhMlFk0wUCtSBdGc.NTYk"
+      }
+    ]
+    |> check_vectors(:sha3_224)
+  end
+
+  test "base pbkdf2_sha3_256 tests" do
+    [
+      {
+        "passDATAb00AB7YxDTT",
+        "saltKEYbcTcXHCBxtjD",
+        100_000,
+        "$pbkdf2-sha3_256$100000$c2FsdEtFWWJjVGNYSENCeHRqRA$gZqwb0K81l6kyiu3oGFA5O8VOCdi3TH0ePxy2Mq3yfc"
+      },
+      {
+        "passDATAb00AB7YxDTTl",
+        "saltKEYbcTcXHCBxtjD2",
+        100_000,
+        "$pbkdf2-sha3_256$100000$c2FsdEtFWWJjVGNYSENCeHRqRDI$aD2gRbMudPxF9zvvYTGyubznqOvF7QDDN0w5cevBUlE"
+      },
+      {
+        "passDATAb00AB7YxDTTlRH2dqxDx19GDxDV1zFMz7E6QVqKIzwOtMnlxQLttpE5",
+        "saltKEYbcTcXHCBxtjD2PnBh44AIQ6XUOCESOhXpEp3HrcGMwbjzQKMSaf63IJe",
+        100_000,
+        "$pbkdf2-sha3_256$100000$c2FsdEtFWWJjVGNYSENCeHRqRDJQbkJoNDRBSVE2WFVPQ0VTT2hYcEVwM0hyY0dNd2JqelFLTVNhZjYzSUpl$ErWVAo/ZhFuJaK5uEUzC2wU0NmcJCsW.yWWFFNOL.VI"
+      }
+    ]
+    |> check_vectors(:sha3_256)
+  end
+
+  test "base pbkdf2_sha3_384 tests" do
+    [
+      {
+        "passDATAb00AB7YxDTT",
+        "saltKEYbcTcXHCBxtjD",
+        100_000,
+        "$pbkdf2-sha3_384$100000$c2FsdEtFWWJjVGNYSENCeHRqRA$meyC2HvX2dXYXZZbnCEW0xwXfGkAw1nuyHBXYAyOl6M"
+      },
+      {
+        "passDATAb00AB7YxDTTl",
+        "saltKEYbcTcXHCBxtjD2",
+        100_000,
+        "$pbkdf2-sha3_384$100000$c2FsdEtFWWJjVGNYSENCeHRqRDI$deki2196K3.RbZaXCjexjNirY6OSBiNWjk1rOctkB84"
+      },
+      {
+        "passDATAb00AB7YxDTTlRH2dqxDx19GDxDV1zFMz7E6QVqKIzwOtMnlxQLttpE5",
+        "saltKEYbcTcXHCBxtjD2PnBh44AIQ6XUOCESOhXpEp3HrcGMwbjzQKMSaf63IJe",
+        100_000,
+        "$pbkdf2-sha3_384$100000$c2FsdEtFWWJjVGNYSENCeHRqRDJQbkJoNDRBSVE2WFVPQ0VTT2hYcEVwM0hyY0dNd2JqelFLTVNhZjYzSUpl$PyYUeHcVFoIQKnXNMe0rx0dRGgoyWUt8PWK/jjTgyRc"
+      }
+    ]
+    |> check_vectors(:sha3_384)
+  end
+
+  test "base pbkdf2_sha3_512 tests" do
+    [
+      {
+        "passDATAb00AB7YxDTT",
+        "saltKEYbcTcXHCBxtjD",
+        100_000,
+        "$pbkdf2-sha3_512$100000$c2FsdEtFWWJjVGNYSENCeHRqRA$/u/I0hidzBedlxovMBogaieD/c/.wC49WJX/3AwkdRLcy8ZSK9EbFnw4X6mhy1cSPGUppCyZsV.1tD3jkFk9yA"
+      },
+      {
+        "passDATAb00AB7YxDTTl",
+        "saltKEYbcTcXHCBxtjD2",
+        100_000,
+        "$pbkdf2-sha3_512$100000$c2FsdEtFWWJjVGNYSENCeHRqRDI$LMnh8/zlHKPJR7BaOWq9l3B7JfIG17U7DNUWlOyImYZXfBit8lIBgM3ANCJ.LX47GAfh26yKxAcuxU2omJKk5g"
+      },
+      {
+        "passDATAb00AB7YxDTTlRH2dqxDx19GDxDV1zFMz7E6QVqKIzwOtMnlxQLttpE5",
+        "saltKEYbcTcXHCBxtjD2PnBh44AIQ6XUOCESOhXpEp3HrcGMwbjzQKMSaf63IJe",
+        100_000,
+        "$pbkdf2-sha3_512$100000$c2FsdEtFWWJjVGNYSENCeHRqRDJQbkJoNDRBSVE2WFVPQ0VTT2hYcEVwM0hyY0dNd2JqelFLTVNhZjYzSUpl$LIHisBpRderrmSG3zGCqaTFK0FSy4zPTKd7EGzN6VD7QvyKdRUFllgDCnBJPv3zcDo1uSzo2xhZSM5JcaOKCeg"
+      }
+    ]
+    |> check_vectors(:sha3_512)
   end
 
   test "Python passlib pbkdf2_sha512 tests" do


### PR DESCRIPTION
It allows decrypting data with other algorithms than SHA256 and SHA512.
For example, it can be used to decrypt messages from the Rails app that
uses the SHA1 HMAC digest by default.

See https://erlang.org/doc/man/crypto.html#type-hmac_hash_algorithm